### PR TITLE
Disable any D1.0 nodes in the migrated D2.0 flow

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,9 +26,9 @@ const MigrateDashboard = {
             }
 
             if (node.type.startsWith('ui_')) {
-                // Unsupported UI node types, don't return anything
-                console.log('Unable to automatically migrate ' + node.type + ' nodes currently')
-                return
+                // Unsupported UI node types, disable them
+                console.log('Unable to automatically migrate ' + node.type + ' nodes currently. Disabling the node.')
+                node.d = true
             }
 
             // We don't have any particular migration logic for this node type

--- a/tests/flows/basic-layout-after.json
+++ b/tests/flows/basic-layout-after.json
@@ -1,8 +1,9 @@
 [
     {
         "id": "3bfec0651634a587",
-        "type": "ui-button",
+        "type": "ui_button",
         "z": "59ec790452bff51d",
+        "d": true,
         "group": "48a06ad17842366f",
         "name": "",
         "label": "button",

--- a/tests/index.js
+++ b/tests/index.js
@@ -98,7 +98,6 @@ describe('Dashboard Migration Script', function () {
 
     describe('Unsupported UI Nodes:', function () {
         it('should should be disabled in the NR Editor', function () {
-            console.log(migratedFlow)
             const button0 = utils.getByType(migratedFlow, 'ui_button')[0]
             const button1 = utils.getByType(basicLayoutAfter, 'ui_button')[0]
             button0.d.should.equal(button1.d)

--- a/tests/index.js
+++ b/tests/index.js
@@ -95,4 +95,13 @@ describe('Dashboard Migration Script', function () {
             group.disabled.should.equal(group1.disabled)
         })
     })
+
+    describe('Unsupported UI Nodes:', function () {
+        it('should should be disabled in the NR Editor', function () {
+            console.log(migratedFlow)
+            const button0 = utils.getByType(migratedFlow, 'ui_button')[0]
+            const button1 = utils.getByType(basicLayoutAfter, 'ui_button')[0]
+            button0.d.should.equal(button1.d)
+        })
+    })
 })


### PR DESCRIPTION
## Description

Previously we removed any D1.0 nodes found that we do not support. Instead, now, this includes them, but disables them in the NR Editor. This ensures that users are clearly shown any nodes that require manual attention.